### PR TITLE
Database Message reference from UUID to ID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
 
     volumes:
     - nifi-io:/io
+    - nifi-conf:/opt/nifi/nifi-current/conf
 
 
   redis:
@@ -116,4 +117,5 @@ services:
 
 volumes:
   nifi-io:
+  nifi-conf:
   sqapi-files:

--- a/resources/docs/EXAMPLE_SYSTEM.md
+++ b/resources/docs/EXAMPLE_SYSTEM.md
@@ -66,6 +66,7 @@ After *Main*, the flow is forked into three:
 * `AttributesToJSON`: Extracts metadata from file, and creates new FlowFile with attributes as JSON content
   * `Destination`: `flowfile-content`
 * `PutDistributedMapCache`: Inserts attributes (metadata) as JSON, into Redis
+  * `Cache Entry Identifier`: `${uuid_ref}`
   * `Distributed Cache Service`: `RedisDistributedMapCacheClientService`
     * `Redis Connection Pool`: `RedisConnectionPoolService`
 

--- a/sqapi/connectors/db/pg_script/select_message.sql
+++ b/sqapi/connectors/db/pg_script/select_message.sql
@@ -1,4 +1,4 @@
 -- Select Message by UUID
 SELECT *
 FROM messages
-WHERE uuid_ref=%(uuid_ref)s;
+WHERE id=%(id)s;

--- a/sqapi/connectors/db/pg_script/update_message.sql
+++ b/sqapi/connectors/db/pg_script/update_message.sql
@@ -3,4 +3,4 @@ UPDATE messages
 SET status = %(status)s,
     info = %(info)s,
     updated_at = Now()
-    WHERE uuid_ref = %(uuid_ref)s;
+    WHERE id = %(id)s;

--- a/sqapi/connectors/db/postgres.py
+++ b/sqapi/connectors/db/postgres.py
@@ -142,7 +142,7 @@ class Database:
 
     def update_message(self, message: dict, status: str, info: str = None):
         log.debug('Updating message if it exists')
-        message.update({'status': status, 'info': info, 'id': str(uuid.uuid4())})
+        message.update({'status': status, 'info': info, 'id': message.get('id', str(uuid.uuid4()))})
         script = UPDATE_MESSAGE_SCRIPT if self.get_message(**message) else INSERT_MESSAGE_SCRIPT
         log.debug('Message script decided')
         log.debug(script)
@@ -152,6 +152,7 @@ class Database:
             log.debug('Result of updating message: {}'.format(out))
         except Exception as e:
             log.debug(str(e))
+            out = None
 
         return out
 


### PR DESCRIPTION
Changed message database reference from uuid to id, so only the current message entry is updated when updating status. Added volume in docker-compose for NiFi configuration, and updated flaw in example setup