### PR TITLE
Added deepcopy to arguments, and now sending sqAPI Message instead of dict

### DIFF
--- a/resources/templates/template_plugin/__init__.py
+++ b/resources/templates/template_plugin/__init__.py
@@ -2,6 +2,8 @@ import io
 import logging
 import os
 
+from sqapi.core.message import Message
+
 SQL_SCRIPT_DIR = '{}/scripts'.format(os.path.dirname(__file__))
 INSERT_ITEM = 'insert_item.sql'
 
@@ -11,7 +13,7 @@ Using default Python logging framework
 log = logging.getLogger(__name__)
 
 
-def execute(config, database, message: dict, metadata: dict, data: io.BufferedReader):
+def execute(config, database, message: Message, metadata: dict, data: io.BufferedReader):
     """
     This is the custom logic, where all data are available through the parameters.
     Create a structured data set and store it in the database, on disk or what ever you want.
@@ -69,9 +71,9 @@ def convert_to_db_insert(message, meta_size, data_size):
     :return: dictionary prepared for database script
     """
     return {
-        'uuid_ref': message.get('uuid_ref', None),
-        'meta_location': message.get('meta_location', None),
-        'data_location': message.get('data_location', None),
+        'uuid_ref': message.uuid,
+        'meta_location': message.meta_location,
+        'data_location': message.data_location,
         'metadata_size': meta_size,
         'data_size': data_size,
     }

--- a/sqapi/core/process_manager.py
+++ b/sqapi/core/process_manager.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import multiprocessing
@@ -60,7 +61,8 @@ class ProcessManager:
             log.debug('Creating processor pool of plugin executions')
             process_pool = [
                 multiprocessing.Process(target=plugin.execute, args=[
-                    plugin.config, plugin.database, message.body, metadata, open(data_path, 'rb')
+                    plugin.config, plugin.database, copy.deepcopy(message),
+                    copy.deepcopy(metadata), open(data_path, 'rb')
                 ]) for plugin in self.plugin_manager.plugins
                 if valid_data_type(message, plugin)
             ]


### PR DESCRIPTION
Added deepcopy for message and metadata when calling on execute functions in plugins - to avoid letting plugins infect or other ways change the object sent to all plugins. Changed the argument to be sqAPI Message object, instead of dictionary. Also updated plugin template to include Message object as argument - instead of the old dict argument. 