### PR TITLE
Removed required metadata configuration if the metadata is not contained in message

### DIFF
--- a/resources/docs/CONFIGURATION.md
+++ b/resources/docs/CONFIGURATION.md
@@ -198,6 +198,15 @@ msg_broker:
 ### Metadata Store
 The metadata store is also defined by a type and connection details.
 
+It is important to notice that a configuration for Metadata store, is not required.
+This is because the metadata is possible to put on the message.
+If it is desirable to put the metadata on the message,
+the `message_fields` > `metadata` reference mentioned above could be used.
+
+If the metadata is not detected in the message,
+nor any configuration for a metadata storage is defined,
+the metadata will be represented as an empty dictionary.
+
 #### Redis
 ##### Example
 ```yaml

--- a/sqapi/core/process_manager.py
+++ b/sqapi/core/process_manager.py
@@ -97,9 +97,12 @@ class ProcessManager:
         if message.metadata:
             log.debug('Loading metadata from message')
             metadata = json.loads(message.metadata)
-        else:
+        elif self.config.meta_store:
             log.debug('Fetching metadata by query')
             metadata = q_meta.fetch_metadata(self.config, message)
+        else:
+            log.debug('No metadata storage defined in configuration, skipping metadata retrieval')
+            metadata = {}
 
         log.debug('Queries completed')
         return data_path, metadata


### PR DESCRIPTION
Added check to see if metadata is configured. Fetching metadata from message if defined, else if defined in configuration: creates a connection to metadata store and downloads, or sets empty metadata if not contained in either message or defined connection in configuration